### PR TITLE
fix: RRE encoding data loss causing visual corruption (v1.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to rustvncserver will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2025-10-23
+
+### Fixed
+- **Critical RRE encoding bug:** Fixed data loss causing severe visual corruption and flickering
+  - Root cause: Encoder had an "efficiency check" that would return 0 subrectangles when RRE encoding was larger than raw
+  - This told VNC clients to paint the entire rectangle with only the background color, discarding all other pixel data
+  - For video content or complex images with many colors, this resulted in constant flickering as frames alternated between partial data (background color only) and complete data
+  - **Solution:** Always encode all pixels as subrectangles, even if RRE is inefficient
+  - Ensures correct visual output at all times; protocol layer can choose different encoding if efficiency is a concern
+  - Eliminates flickering and visual artifacts when using RRE encoding
+
 ## [1.1.3] - 2025-01-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustvncserver"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Dustin McAfee"]

--- a/src/encoding/rre.rs
+++ b/src/encoding/rre.rs
@@ -47,17 +47,9 @@ impl Encoding for RreEncoding {
         // Find all subrectangles
         let subrects = find_subrects(&pixels, width as usize, height as usize, bg_color);
 
-        // Check if RRE is worth it (otherwise would be larger than raw)
+        // Always encode all pixels to avoid data loss
+        // (Even if RRE is inefficient, we must preserve the image correctly)
         let encoded_size = 4 + 4 + (subrects.len() * (4 + 8)); // header + bg + subrects
-        let raw_size = width as usize * height as usize * 4; // 4 bytes per pixel for 32bpp
-
-        if encoded_size >= raw_size {
-            // Fall back to raw encoding within RRE format (0 subrects)
-            let mut buf = BytesMut::with_capacity(4 + 4);
-            buf.put_u32(0); // 0 subrects (big-endian)
-            buf.put_u32_le(bg_color); // background color in client format (little-endian)
-            return buf;
-        }
 
         let mut buf = BytesMut::with_capacity(encoded_size);
 


### PR DESCRIPTION
Fixed a critical bug in RRE encoding where rectangles with many colors would lose pixel data, causing severe flickering and visual artifacts.

The encoder previously had an "efficiency check" that would return 0 subrectangles when RRE encoding was larger than raw. This told VNC clients to paint the entire rectangle with only the background color, discarding all other pixel data.

For video content or complex images with many colors, this resulted in constant flickering as frames alternated between partial data (background color only) and complete data.

Solution: Always encode all pixels as subrectangles, even if RRE is inefficient. This ensures correct visual output at all times. The protocol layer can choose a different encoding if efficiency is a concern.