### PR TITLE
update dependency and fix warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ crate-type = ["cdylib", "rlib"]
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "net", "io-util", "macros"] }
 bytes = "1"
 log = "0.4"
-thiserror = "1.0"       # Error handling
+thiserror = "2.0"       # Error handling
 des = "0.8"             # DES encryption for VNC auth
-rand = "0.8"            # Random number generation for auth
+rand = "0.9"            # Random number generation for auth
 flate2 = "1.0"          # Zlib compression for Tight encoding
 rfb-encodings = "0.1.6"   # RFB encoding implementations
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -68,7 +68,7 @@ impl VncAuth {
     /// A `[u8; 16]` array containing the random challenge bytes.
     #[allow(clippy::unused_self)] // Kept as method for API consistency with other VncAuthenticator methods
     pub fn generate_challenge(&self) -> [u8; 16] {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut challenge = [0u8; 16];
         rng.fill(&mut challenge);
         challenge

--- a/src/client.rs
+++ b/src/client.rs
@@ -1118,13 +1118,15 @@ impl VncClient {
             not(feature = "debug-logging"),
             allow(unused_variables, unused_assignments)
         )]
-        let mut total_pixels = 0u64;
+        #[cfg(feature = "debug-logging")]
+        {
+            let mut total_pixels = 0u64;
+            let mut copy_rect_count = 0;
+        }
         #[cfg_attr(
             not(feature = "debug-logging"),
             allow(unused_variables, unused_assignments)
         )]
-        let mut copy_rect_count = 0;
-
         // Load quality/compression settings atomically
         let jpeg_quality = self.jpeg_quality.load(Ordering::Relaxed);
         let compression_level = self.compression_level.load(Ordering::Relaxed);
@@ -1155,9 +1157,11 @@ impl VncClient {
                 // CopyRect data is just src_x and src_y
                 response.put_u16(src_x);
                 response.put_u16(src_y);
-
-                total_pixels += u64::from(region.width) * u64::from(region.height);
-                copy_rect_count += 1;
+                #[cfg(feature = "debug-logging")]
+                {
+                    total_pixels += u64::from(region.width) * u64::from(region.height);
+                    copy_rect_count += 1;
+                }
             }
         }
 
@@ -1223,11 +1227,10 @@ impl VncClient {
 
                     rect.write_header(&mut response);
                     response.extend_from_slice(encoded);
-
-                    total_pixels += u64::from(*w) * u64::from(*h);
-
                     #[cfg(feature = "debug-logging")]
                     {
+                        total_pixels += u64::from(*w) * u64::from(*h);
+
                         rect_count += 1;
                     }
                 }
@@ -1323,8 +1326,10 @@ impl VncClient {
 
                                 // Write encoder output (background color + subrectangle data)
                                 response.extend_from_slice(&encoded);
-
-                                total_pixels += u64::from(tile_width) * u64::from(tile_height);
+                                #[cfg(feature = "debug-logging")]
+                                {
+                                    total_pixels += u64::from(tile_width) * u64::from(tile_height);
+                                }
                             }
 
                             x += tile_width;
@@ -1705,8 +1710,10 @@ impl VncClient {
                 };
                 rect.write_header(&mut response);
                 response.extend_from_slice(&encoded);
-
-                total_pixels += u64::from(region.width) * u64::from(region.height);
+                #[cfg(feature = "debug-logging")]
+                {
+                    total_pixels += u64::from(region.width) * u64::from(region.height);
+                }
             }
         }
 


### PR DESCRIPTION
This pull request updates dependencies and makes several improvements to conditional debug logging in the VNC client implementation. The most significant changes are the upgrade of the `thiserror` and `rand` crates, a fix to how random numbers are generated for authentication, and the scoping of debug logging variables and code to only compile when the `debug-logging` feature is enabled.

**Dependency upgrades:**

* Updated `thiserror` from version 1.0 to 2.0 in `Cargo.toml` for improved error handling support.
* Updated `rand` from version 0.8 to 0.9 in `Cargo.toml` to keep up with the latest random number generation APIs.

**Authentication improvements:**

* Changed the random number generator in `VncAuth::generate_challenge` to use `rand::rng()` instead of `rand::thread_rng()` for compatibility with `rand` 0.9.

**Debug logging improvements in `VncClient`:**

* Scoped debug logging variables such as `total_pixels` and `copy_rect_count` to only be compiled when the `debug-logging` feature is enabled, reducing unnecessary variable usage in release builds. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R1121-L1127) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1158-R1166)
* Moved accumulation of debug statistics (like `total_pixels` and `rect_count`) into `#[cfg(feature = "debug-logging")]` blocks to avoid affecting performance or logic when debug logging is disabled. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1226-R1233) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1326-R1333) [[3]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1708-R1718)